### PR TITLE
Add method: create_ad_audience_with_pixel

### DIFF
--- a/lib/facebook_ads/ad_account.rb
+++ b/lib/facebook_ads/ad_account.rb
@@ -102,6 +102,19 @@ module FacebookAds
       self.class.get("/#{id}/advertisable_applications", objectify: false)
     end
 
+    def create_ad_audience_with_pixel(name:, pixel_id:, event_name:)
+      query = {
+          name: name,
+          pixel_id: pixel_id,
+          subtype: 'WEBSITE',
+          retention_days: 15,
+          rule: { event: { i_contains: event_name } }.to_json,
+          prefill: 1
+        }
+      result = AdAudience.post("/#{id}/customaudiences", query: query)
+      AdAudience.find(result['id'])
+    end
+
     private
 
     def create_carousel_ad_creative(creative)


### PR DESCRIPTION
Usage: 

1. Set account:

`FacebookAds.access_token = '<ACCESS_TOKEN>'`
`account = FacebookAds::AdAccount.find('< AD_ACCOUNT_ID >')`

2. create ad_audience with pixel:

`account.create_ad_audience_with_pixel(name: '< NAME >', pixel_id: '< PIXEL_ID >', event_name: '< EVENT_NAME >')`

PS: Use standard event name only
- ViewContent
- Search
- AddToCart
- AddToWishlist
- InitiateCheckout
- AddPaymentInfo
- Purchase
- Lead
- CompleteRegistration

e.g. : `account.create_ad_audience_with_pixel(name: 'order complated', pixel_id: '328989100788312', event: 'Purchase')`